### PR TITLE
Cherrypick ctdb fixes to ignore binding to non local ips

### DIFF
--- a/ctdb/common/system_socket.c
+++ b/ctdb/common/system_socket.c
@@ -163,7 +163,7 @@ bool ctdb_sys_local_ip_check(const struct ctdb_sys_local_ips_context *ips_ctx,
 /*
  * See if the given IP is currently on an interface
  */
-bool ctdb_sys_have_ip(ctdb_sock_addr *_addr)
+bool ctdb_sys_have_ip(const ctdb_sock_addr *_addr)
 {
 	int s;
 	int ret;

--- a/ctdb/common/system_socket.h
+++ b/ctdb/common/system_socket.h
@@ -30,7 +30,7 @@ int ctdb_sys_local_ips_init(TALLOC_CTX *ctx,
 			    struct ctdb_sys_local_ips_context **ips_ctx);
 bool ctdb_sys_local_ip_check(const struct ctdb_sys_local_ips_context *ips_ctx,
 			     const ctdb_sock_addr *addr);
-bool ctdb_sys_have_ip(ctdb_sock_addr *addr);
+bool ctdb_sys_have_ip(const ctdb_sock_addr *addr);
 
 int ctdb_sys_send_arp(const ctdb_sock_addr *addr, const char *iface);
 

--- a/ctdb/common/system_socket.h
+++ b/ctdb/common/system_socket.h
@@ -20,8 +20,16 @@
 #ifndef __CTDB_SYSTEM_SOCKET_H__
 #define __CTDB_SYSTEM_SOCKET_H__
 
+#include <talloc.h>
+
 #include "protocol/protocol.h"
 
+struct ctdb_sys_local_ips_context;
+
+int ctdb_sys_local_ips_init(TALLOC_CTX *ctx,
+			    struct ctdb_sys_local_ips_context **ips_ctx);
+bool ctdb_sys_local_ip_check(const struct ctdb_sys_local_ips_context *ips_ctx,
+			     const ctdb_sock_addr *addr);
 bool ctdb_sys_have_ip(ctdb_sock_addr *addr);
 
 int ctdb_sys_send_arp(const ctdb_sock_addr *addr, const char *iface);

--- a/ctdb/common/system_socket.h
+++ b/ctdb/common/system_socket.h
@@ -30,6 +30,7 @@ int ctdb_sys_local_ips_init(TALLOC_CTX *ctx,
 			    struct ctdb_sys_local_ips_context **ips_ctx);
 bool ctdb_sys_local_ip_check(const struct ctdb_sys_local_ips_context *ips_ctx,
 			     const ctdb_sock_addr *addr);
+bool ctdb_sys_bind_ip_check(const ctdb_sock_addr *addr);
 bool ctdb_sys_have_ip(const ctdb_sock_addr *addr);
 
 int ctdb_sys_send_arp(const ctdb_sock_addr *addr, const char *iface);

--- a/ctdb/doc/ctdb.conf.5.xml
+++ b/ctdb/doc/ctdb.conf.5.xml
@@ -241,9 +241,11 @@
 	    This option is only required when automatic address
 	    detection can not be used.  This can be the case when
 	    running multiple ctdbd daemons/nodes on the same physical
-	    host (usually for testing), using InfiniBand for the
-	    private network or on Linux when sysctl
-	    net.ipv4.ip_nonlocal_bind=1.
+	    host (usually for testing) or using InfiniBand for the
+	    private network.  Another unlikely possibility would be
+	    running on a platform with a feature like Linux's
+	    net.ipv4.ip_nonlocal_bind=1 enabled and no usable
+	    getifaddrs(3) implementation (or replacement) available.
 	  </para>
 	  <para>
 	    Default: CTDB selects the first address from the nodes

--- a/ctdb/protocol/protocol_util.c
+++ b/ctdb/protocol/protocol_util.c
@@ -379,6 +379,25 @@ int ctdb_sock_addr_mask_from_string(const char *str,
 	return ret;
 }
 
+int ctdb_sock_addr_from_sockaddr(struct sockaddr *addr,
+				 ctdb_sock_addr *sock_addr)
+{
+	switch (addr->sa_family) {
+	case AF_INET:
+		ZERO_STRUCTP(sock_addr);
+		sock_addr->ip = *(struct sockaddr_in *)addr;
+		break;
+	case AF_INET6:
+		ZERO_STRUCTP(sock_addr);
+		sock_addr->ip6 = *(struct sockaddr_in6 *)addr;
+		break;
+	default:
+		return EINVAL;
+	}
+
+	return 0;
+}
+
 unsigned int ctdb_sock_addr_port(ctdb_sock_addr *addr)
 {
 	switch (addr->sa.sa_family) {

--- a/ctdb/protocol/protocol_util.h
+++ b/ctdb/protocol/protocol_util.h
@@ -44,6 +44,8 @@ int ctdb_sock_addr_from_string(const char *str,
 int ctdb_sock_addr_mask_from_string(const char *str,
 				    ctdb_sock_addr *addr,
 				    unsigned int *mask);
+int ctdb_sock_addr_from_sockaddr(struct sockaddr *addr,
+				 ctdb_sock_addr *sock_addr);
 unsigned int ctdb_sock_addr_port(ctdb_sock_addr *addr);
 void ctdb_sock_addr_set_port(ctdb_sock_addr *addr, unsigned int port);
 int ctdb_sock_addr_cmp_ip(const ctdb_sock_addr *addr1,

--- a/ctdb/server/ctdb_recoverd.c
+++ b/ctdb/server/ctdb_recoverd.c
@@ -2356,18 +2356,19 @@ static int verify_local_ip_allocation(struct ctdb_recoverd *rec)
 	}
 
 	for (j=0; j<ips->num; j++) {
+		ctdb_sock_addr *addr = &ips->ips[j].addr;
+		bool have_ip = ctdb_sys_have_ip(addr);
+
 		if (ips->ips[j].pnn == rec->pnn) {
-			if (!ctdb_sys_have_ip(&ips->ips[j].addr)) {
-				DEBUG(DEBUG_ERR,
-				      ("Assigned IP %s not on an interface\n",
-				       ctdb_addr_to_str(&ips->ips[j].addr)));
+			if (!have_ip) {
+				D_ERR("Assigned IP %s not on an interface\n",
+				      ctdb_addr_to_str(addr));
 				need_takeover_run = true;
 			}
 		} else {
-			if (ctdb_sys_have_ip(&ips->ips[j].addr)) {
-				DEBUG(DEBUG_ERR,
-				      ("IP %s incorrectly on an interface\n",
-				       ctdb_addr_to_str(&ips->ips[j].addr)));
+			if (have_ip) {
+				D_ERR("IP %s incorrectly on an interface\n",
+				      ctdb_addr_to_str(addr));
 				need_takeover_run = true;
 			}
 		}

--- a/ctdb/tcp/tcp_connect.c
+++ b/ctdb/tcp/tcp_connect.c
@@ -500,7 +500,8 @@ static int ctdb_tcp_listen_automatic(struct ctdb_context *ctdb)
 	 * process.
 	 */
 	if (ctdb->num_nodes == 0) {
-		DEBUG(DEBUG_CRIT,("No nodes available to attempt bind to - is the nodes file empty?\n"));
+		D_ERR("No nodes available to attempt bind to - "
+		      "is the nodes file empty?\n");
 		return -1;
 	}
 

--- a/ctdb/tcp/tcp_connect.c
+++ b/ctdb/tcp/tcp_connect.c
@@ -36,6 +36,8 @@
 #include "common/logging.h"
 #include "common/path.h"
 
+#include "protocol/protocol_util.h"
+
 #include "ctdb_tcp.h"
 
 /*
@@ -319,8 +321,14 @@ static void ctdb_listen_event(struct tevent_context *ev, struct tevent_fd *fde,
 
 	node = ctdb_ip_to_node(ctdb, &addr);
 	if (node == NULL) {
-		D_ERR("Refused connection from unknown node %s\n",
-		      ctdb_addr_to_str(&addr));
+		char *t = ctdb_sock_addr_to_string(ctcp, &addr, true);
+		if (t == NULL) {
+			DBG_ERR("Refused connection from unparsable node\n");
+			goto failed;
+		}
+
+		D_ERR("Refused connection from unknown node %s\n", t);
+		talloc_free(t);
 		goto failed;
 	}
 

--- a/ctdb/tcp/tcp_connect.c
+++ b/ctdb/tcp/tcp_connect.c
@@ -496,9 +496,7 @@ static int ctdb_tcp_listen_automatic(struct ctdb_context *ctdb)
 		goto failed;
 	}
 
-	ctdb->name = talloc_asprintf(ctdb, "%s:%u",
-				     ctdb_addr_to_str(ctdb->address),
-				     ctdb_addr_to_port(ctdb->address));
+	ctdb->name = talloc_strdup(ctdb, ctdb->nodes[i]->name);
 	if (ctdb->name == NULL) {
 		ctdb_set_error(ctdb, "Out of memory at %s:%d",
 			       __FILE__, __LINE__);

--- a/ctdb/tcp/tcp_connect.c
+++ b/ctdb/tcp/tcp_connect.c
@@ -330,14 +330,14 @@ static void ctdb_listen_event(struct tevent_context *ev, struct tevent_fd *fde,
 	if (tnode == NULL) {
 		/* This can't happen - see ctdb_tcp_initialise() */
 		DBG_ERR("INTERNAL ERROR setting up connection from node %s\n",
-			ctdb_addr_to_str(&addr));
+			node->name);
 		close(fd);
 		return;
 	}
 
 	if (tnode->in_queue != NULL) {
 		DBG_ERR("Incoming queue active, rejecting connection from %s\n",
-			ctdb_addr_to_str(&addr));
+			node->name);
 		close(fd);
 		return;
 	}
@@ -371,7 +371,7 @@ static void ctdb_listen_event(struct tevent_context *ev, struct tevent_fd *fde,
 					   ctdb_tcp_read_cb,
 					   node,
 					   "ctdbd-%s",
-					   ctdb_addr_to_str(&addr));
+					   node->name);
 	if (tnode->in_queue == NULL) {
 		DBG_ERR("Failed to set up incoming queue\n");
 		close(fd);

--- a/ctdb/tests/src/system_socket_test.c
+++ b/ctdb/tests/src/system_socket_test.c
@@ -222,12 +222,30 @@ static void test_tcp(const char *src_str,
 	assert(ret == 0);
 }
 
+static void test_haveip(const char *ipaddr_str)
+{
+	ctdb_sock_addr addr;
+	bool have_ip;
+	int ret;
+
+	ret = ctdb_sock_addr_from_string(ipaddr_str, &addr, false);
+	assert(ret == 0);
+
+	have_ip = ctdb_sys_have_ip(&addr);
+	if (have_ip) {
+		printf("true\n");
+	} else {
+		printf("false\n");
+	}
+}
+
 static void usage(const char *prog)
 {
 	fprintf(stderr, "usage: %s <cmd> [<arg> ...]\n", prog);
 	fprintf(stderr, "  commands:\n");
 	fprintf(stderr, "    types\n");
 	fprintf(stderr, "    arp <ipaddr> <hwaddr> [reply]\n");
+	fprintf(stderr, "    haveip <ipaddr>\n");
 	fprintf(stderr, "    tcp <src> <dst> <seq> <ack> <rst>\n");
 
 	exit(1);
@@ -258,6 +276,11 @@ int main(int argc, char **argv)
 			usage(argv[0]);
 		}
 		test_tcp(argv[2], argv[3], argv[4], argv[5], argv[6]);
+	} else if (strcmp(argv[1], "haveip") == 0) {
+		if (argc != 3) {
+			usage(argv[0]);
+		}
+		test_haveip(argv[2]);
 	} else {
 		usage(argv[0]);
 	}

--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -402,6 +402,7 @@ def build(bld):
                         includes='include',
                         deps='''ctdb-protocol-util
                                 ctdb-system
+                                ctdb-util
                                 replace
                                 talloc
                                 tdb

--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -415,7 +415,15 @@ def build(bld):
     bld.SAMBA_SUBSYSTEM('ctdb-system',
                         source=bld.SUBDIR('common',
                                           'system_socket.c system.c'),
-                        deps='replace talloc tevent tdb pcap samba-util')
+                        deps='''ctdb-protocol
+                                ctdb-protocol-util
+                                pcap
+                                replace
+                                samba-util
+                                talloc
+                                tdb
+                                tevent
+                             ''')
 
     bld.SAMBA_SUBSYSTEM('ctdb-common',
                         source=bld.SUBDIR('common',

--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -400,7 +400,13 @@ def build(bld):
                         source=bld.SUBDIR('tcp',
                                           'tcp_connect.c tcp_init.c tcp_io.c'),
                         includes='include',
-                        deps='replace tdb talloc tevent ctdb-protocol-util')
+                        deps='''ctdb-protocol-util
+                                ctdb-system
+                                replace
+                                talloc
+                                tdb
+                                tevent
+                             ''')
 
     ib_deps = ''
     if bld.env.HAVE_INFINIBAND:

--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -400,7 +400,7 @@ def build(bld):
                         source=bld.SUBDIR('tcp',
                                           'tcp_connect.c tcp_init.c tcp_io.c'),
                         includes='include',
-                        deps='replace tdb talloc tevent')
+                        deps='replace tdb talloc tevent ctdb-protocol-util')
 
     ib_deps = ''
     if bld.env.HAVE_INFINIBAND:


### PR DESCRIPTION
In addition to the minimum required patches we have 6 preparatory changes with a follow up change at the top for clean and complete cherry-pick from upstream.