### PR TITLE
Release 9.2: Initialise librgw only once per client in vfs_ceph_rgw

### DIFF
--- a/docs-xml/manpages/vfs_ceph_rgw.8.xml
+++ b/docs-xml/manpages/vfs_ceph_rgw.8.xml
@@ -89,16 +89,33 @@
 </refsect1>
 
 <refsect1>
-	<title>OPTIONS</title>
+	<title>GLOBAL OPTIONS</title>
+
+	<para>The following options must be set in the global smb.conf section
+	and won't take effect when set per share. librgw can only be
+	initialised once per process, so these parameters are shared across
+	all shares.</para>
 
 	<variablelist>
+
+		<varlistentry>
+		<term>ceph_rgw:id = name</term>
+		<listitem>
+		<para>
+			Client id portion of the Ceph client name used by librgw.
+			(Required)
+		</para>
+		<para>
+			Example: ceph_rgw:id = admin
+		</para>
+		</listitem>
+		</varlistentry>
 
 		<varlistentry>
 		<term>ceph_rgw:config_file = path</term>
 		<listitem>
 		<para>
 			Allows one to define a ceph configuration to use.
-			(Required)
 			Default:
 			/etc/ceph/ceph.conf
 		</para>
@@ -124,10 +141,34 @@
 		</varlistentry>
 
 		<varlistentry>
+		<term>ceph_rgw:debug = boolean</term>
+		<listitem>
+		<para>
+			Control debug logs for librgw.
+			Default: off
+		</para>
+		<para>
+			Example: ceph_rgw:debug = on
+		</para>
+		</listitem>
+		</varlistentry>
+
+	</variablelist>
+
+</refsect1>
+
+<refsect1>
+	<title>OPTIONS</title>
+
+	<para>The following options can be set per share.</para>
+
+	<variablelist>
+
+		<varlistentry>
 		<term>ceph_rgw:user_id = name</term>
 		<listitem>
 		<para>
-			User id of bucket owner
+			User id of bucket owner.
 			(Required)
 		</para>
 		<para>
@@ -175,33 +216,6 @@
 		</listitem>
 		</varlistentry>
 
-		<varlistentry>
-		<term>ceph_rgw:debug = boolean</term>
-		<listitem>
-		<para>
-			Control debug logs for librgw
-			(Optional)
-			Default: off
-		</para>
-		<para>
-			Example: ceph_rgw:debug = on
-		</para>
-		</listitem>
-		</varlistentry>
-
-		<varlistentry>
-		<term>ceph_rgw:id = name</term>
-		<listitem>
-		<para>
-			Client id portion of the Ceph client name used by librgw
-			(Required)
-		</para>
-		<para>
-			Example: ceph_rgw:id = admin
-		</para>
-		</listitem>
-		</varlistentry>
-
 	</variablelist>
 
 </refsect1>
@@ -233,6 +247,11 @@
 		</para>
 		<para>
 			<programlisting>
+			<smbconfsection name="[global]"/>
+			<smbconfoption name="ceph_rgw:id">admin</smbconfoption>
+			<smbconfoption name="ceph_rgw:config_file">/etc/ceph/ceph.conf</smbconfoption>
+			<smbconfoption name="ceph_rgw:keyring_file">/etc/ceph/ceph.client.admin.keyring</smbconfoption>
+
 			<smbconfsection name="[share]"/>
 			<smbconfoption name="comment">rgw bucket</smbconfoption>
 			<smbconfoption name="path">/</smbconfoption>
@@ -240,13 +259,9 @@
 			<smbconfoption name="inherit permissions">yes</smbconfoption>
 			<smbconfoption name="vfs objects">ceph_rgw</smbconfoption>
 			<smbconfoption name="ceph_rgw:bucket">my-bucket</smbconfoption>
-			<smbconfoption name="ceph_rgw:id">admin</smbconfoption>
 			<smbconfoption name="ceph_rgw:user_id">user1</smbconfoption>
 			<smbconfoption name="ceph_rgw:access_key">user1passwd</smbconfoption>
 			<smbconfoption name="ceph_rgw:secret_access_key">user1passwd</smbconfoption>
-			<smbconfoption name="ceph_rgw:config_file">/etc/ceph/ceph.conf</smbconfoption>
-			<smbconfoption name="ceph_rgw:keyring_file">/etc/ceph/ceph.client.admin.keyring</smbconfoption>
-			<smbconfoption name="ceph_rgw:debug">off</smbconfoption>
 			</programlisting>
 		</para>
 		</listitem>

--- a/source3/modules/vfs_ceph_rgw.c
+++ b/source3/modules/vfs_ceph_rgw.c
@@ -2260,6 +2260,9 @@ static bool vfs_ceph_rgw_load_config(struct vfs_handle_struct *handle,
 	*config = config_tmp;
 	ret = true;
 out:
+	if (!ret) {
+		TALLOC_FREE(config_tmp);
+	}
 	return ret;
 }
 

--- a/source3/modules/vfs_ceph_rgw.c
+++ b/source3/modules/vfs_ceph_rgw.c
@@ -42,20 +42,22 @@
 
 static uint64_t rgw_fd_index = 0;
 
+struct vfs_ceph_rgw_lib {
+	librgw_t handle;
+	unsigned int refcount;
+};
+
+static struct vfs_ceph_rgw_lib *g_rgw_lib;
+
 struct vfs_ceph_rgw_config {
 
 	/* Module parameters */
-	const char *id;
 	const char *bkt_name;
 	const char *user_id;
 	const char *access_key;
 	const char *secret_access_key;
-	const char *config_file;
-	const char *keyring_file;
-	bool debug;
 
 	/* rgw objects */
-	librgw_t rgw_lib_handle;
 	struct rgw_fs *rgw_root_fs;
 	struct rgw_file_handle *rgw_root_fh;
 };
@@ -2103,47 +2105,8 @@ static bool vfs_ceph_rgw_mount_bucket(struct vfs_ceph_rgw_config *config)
 {
 	int rc = 0;
 	bool ret = false;
-	char **librgw_params = talloc_zero_array(talloc_tos(), char *, 2);
 
-	if (librgw_params == NULL) {
-		DBG_ERR("[CEPH_RGW] Not enough memory for librgw params\n");
-		errno = ENOMEM;
-		goto out;
-	}
-
-	/* Prepare parameters */
-	librgw_params[0] = talloc_strdup(librgw_params, "vfs_ceph_rgw");
-	if (librgw_params[0] == NULL) {
-		DBG_ERR("[CEPH_RGW] Not enough memory for librgw params\n");
-		errno = ENOMEM;
-		goto out;
-	}
-
-	librgw_params[1] = talloc_asprintf(
-		librgw_params,
-		"--id=%s --conf=%s "
-		"--keyring=%s",
-		config->id,
-		config->config_file,
-		config->keyring_file);
-	if (librgw_params[1] == NULL) {
-		DBG_ERR("[CEPH_RGW] Not enough memory for librgw params\n");
-		errno = ENOMEM;
-		goto out;
-	}
-
-	if (config->debug) {
-		talloc_asprintf_addbuf(librgw_params + 1,
-				       " -d --debug-rgw=20");
-	}
-
-	rc = librgw_create(&config->rgw_lib_handle, 2, librgw_params);
-	if (rc != 0) {
-		DBG_ERR("[CEPH_RGW] Failed to init librgw. rc=%d\n", rc);
-		goto out;
-	}
-
-	rc = rgw_mount2(config->rgw_lib_handle,
+	rc = rgw_mount2(g_rgw_lib->handle,
 			config->user_id,
 			config->access_key,
 			config->secret_access_key,
@@ -2157,7 +2120,6 @@ static bool vfs_ceph_rgw_mount_bucket(struct vfs_ceph_rgw_config *config)
 			((rc == -EINVAL) ? "Un-authorised user"
 					 : "unknown error"),
 			rc);
-		librgw_shutdown(config->rgw_lib_handle);
 		goto out;
 	}
 
@@ -2165,7 +2127,6 @@ static bool vfs_ceph_rgw_mount_bucket(struct vfs_ceph_rgw_config *config)
 	ret = true;
 
 out:
-	TALLOC_FREE(librgw_params);
 	return ret;
 }
 
@@ -2205,25 +2166,6 @@ static bool vfs_ceph_rgw_load_config(struct vfs_handle_struct *handle,
 		goto out;
 	}
 
-	config_tmp->id = vfs_ceph_rgw_parm(-1, "id", NULL);
-	if (config_tmp->id == NULL) {
-		goto out;
-	}
-
-	config_tmp->config_file = vfs_ceph_rgw_parm(-1,
-						    "config_file",
-						    "/etc/ceph/ceph.conf");
-	if (config_tmp->config_file == NULL) {
-		goto out;
-	}
-
-	config_tmp->keyring_file = vfs_ceph_rgw_parm(-1,
-						     "keyring_file",
-						     NULL);
-	if (config_tmp->keyring_file == NULL) {
-		goto out;
-	}
-
 	config_tmp->user_id = vfs_ceph_rgw_parm(SNUM(handle->conn),
 						"user_id",
 						NULL);
@@ -2252,8 +2194,6 @@ static bool vfs_ceph_rgw_load_config(struct vfs_handle_struct *handle,
 		goto out;
 	}
 
-	config_tmp->debug = lp_parm_bool(-1, "ceph_rgw", "debug", false);
-
 	SMB_VFS_HANDLE_SET_DATA(handle,
 				config_tmp,
 				NULL,
@@ -2267,6 +2207,77 @@ out:
 		TALLOC_FREE(config_tmp);
 	}
 	return ret;
+}
+
+static bool vfs_ceph_rgw_lib_init(void)
+{
+	int rc = 0;
+	bool ok = false;
+	const char *id = NULL;
+	const char *config_file = NULL;
+	const char *keyring_file = NULL;
+	bool debug;
+	char **librgw_params = talloc_zero_array(talloc_tos(), char *, 2);
+
+	if (librgw_params == NULL) {
+		DBG_ERR("[CEPH_RGW] Not enough memory for librgw params\n");
+		errno = ENOMEM;
+		goto out;
+	}
+
+	id = vfs_ceph_rgw_parm(-1, "id", NULL);
+	if (id == NULL) {
+		goto out;
+	}
+
+	config_file = vfs_ceph_rgw_parm(-1,
+					"config_file",
+					"/etc/ceph/ceph.conf");
+	if (config_file == NULL) {
+		goto out;
+	}
+
+	keyring_file = vfs_ceph_rgw_parm(-1, "keyring_file", NULL);
+	if (keyring_file == NULL) {
+		goto out;
+	}
+
+	debug = lp_parm_bool(-1, "ceph_rgw", "debug", false);
+
+	/* Prepare parameters */
+	librgw_params[0] = talloc_strdup(librgw_params, "vfs_ceph_rgw");
+	if (librgw_params[0] == NULL) {
+		DBG_ERR("[CEPH_RGW] Not enough memory for librgw params\n");
+		errno = ENOMEM;
+		goto out;
+	}
+
+	librgw_params[1] = talloc_asprintf(librgw_params,
+					   "--id=%s --conf=%s --keyring=%s",
+					   id,
+					   config_file,
+					   keyring_file);
+	if (librgw_params[1] == NULL) {
+		DBG_ERR("[CEPH_RGW] Not enough memory for librgw params\n");
+		errno = ENOMEM;
+		goto out;
+	}
+
+	if (debug) {
+		talloc_asprintf_addbuf(librgw_params + 1,
+				       " -d --debug-rgw=20");
+	}
+
+	rc = librgw_create(&g_rgw_lib->handle, 2, librgw_params);
+	if (rc != 0) {
+		DBG_ERR("[CEPH_RGW] Failed to init librgw. rc=%d\n", rc);
+		goto out;
+	}
+
+	ok = true;
+out:
+	TALLOC_FREE(librgw_params);
+	return ok;
 }
 
 static int vfs_ceph_rgw_connect(struct vfs_handle_struct *handle,
@@ -2296,10 +2307,23 @@ static int vfs_ceph_rgw_connect(struct vfs_handle_struct *handle,
 	 */
 	lp_do_parameter(SNUM(handle->conn), "aio write size", "0");
 
+	if (g_rgw_lib->handle == NULL) {
+		ok = vfs_ceph_rgw_lib_init();
+		if (!ok) {
+			return -1;
+		}
+	}
+
 	ok = vfs_ceph_rgw_mount_bucket(config);
 	if (!ok) {
+		if (g_rgw_lib->refcount == 0) {
+			librgw_shutdown(g_rgw_lib->handle);
+			g_rgw_lib->handle = NULL;
+		}
 		return -1;
 	}
+
+	g_rgw_lib->refcount++;
 
 	return 0;
 }
@@ -2321,7 +2345,11 @@ static void vfs_ceph_rgw_disconnect(struct vfs_handle_struct *handle)
 			ret);
 	}
 
-	librgw_shutdown(config->rgw_lib_handle);
+	g_rgw_lib->refcount--;
+	if (g_rgw_lib->refcount == 0) {
+		librgw_shutdown(g_rgw_lib->handle);
+		g_rgw_lib->handle = NULL;
+	}
 
 	TALLOC_FREE(config);
 }
@@ -2410,6 +2438,12 @@ static struct vfs_fn_pointers ceph_rgw_fns = {
 
 NTSTATUS vfs_ceph_rgw_init(TALLOC_CTX *ctx)
 {
+	g_rgw_lib = talloc_zero(ctx, struct vfs_ceph_rgw_lib);
+	if (g_rgw_lib == NULL) {
+		DBG_ERR("[CEPH_RGW] Not enough memory\n");
+		return NT_STATUS_NO_MEMORY;
+	}
+
 	return smb_register_vfs(SMB_VFS_INTERFACE_VERSION,
 				"ceph_rgw",
 				&ceph_rgw_fns);

--- a/source3/modules/vfs_ceph_rgw.c
+++ b/source3/modules/vfs_ceph_rgw.c
@@ -2169,11 +2169,10 @@ out:
 	return ret;
 }
 
-static const char *vfs_ceph_rgw_parm(const struct vfs_handle_struct *handle,
+static const char *vfs_ceph_rgw_parm(int snum,
 				     const char *opt,
 				     const char *def)
 {
-	const int snum = SNUM(handle->conn);
 	const char *parm = NULL;
 
 	parm = lp_parm_const_string(snum, "ceph_rgw", opt, def);
@@ -2206,51 +2205,55 @@ static bool vfs_ceph_rgw_load_config(struct vfs_handle_struct *handle,
 		goto out;
 	}
 
-	config_tmp->id = vfs_ceph_rgw_parm(handle, "id", NULL);
+	config_tmp->id = vfs_ceph_rgw_parm(-1, "id", NULL);
 	if (config_tmp->id == NULL) {
 		goto out;
 	}
 
-	config_tmp->config_file = vfs_ceph_rgw_parm(handle,
+	config_tmp->config_file = vfs_ceph_rgw_parm(-1,
 						    "config_file",
 						    "/etc/ceph/ceph.conf");
 	if (config_tmp->config_file == NULL) {
 		goto out;
 	}
 
-	config_tmp->keyring_file = vfs_ceph_rgw_parm(handle,
+	config_tmp->keyring_file = vfs_ceph_rgw_parm(-1,
 						     "keyring_file",
 						     NULL);
 	if (config_tmp->keyring_file == NULL) {
 		goto out;
 	}
 
-	config_tmp->user_id = vfs_ceph_rgw_parm(handle, "user_id", NULL);
+	config_tmp->user_id = vfs_ceph_rgw_parm(SNUM(handle->conn),
+						"user_id",
+						NULL);
 	if (config_tmp->user_id == NULL) {
 		goto out;
 	}
 
-	config_tmp->access_key = vfs_ceph_rgw_parm(handle, "access_key", NULL);
+	config_tmp->access_key = vfs_ceph_rgw_parm(SNUM(handle->conn),
+						   "access_key",
+						   NULL);
 	if (config_tmp->access_key == NULL) {
 		goto out;
 	}
 
-	config_tmp->secret_access_key = vfs_ceph_rgw_parm(handle,
+	config_tmp->secret_access_key = vfs_ceph_rgw_parm(SNUM(handle->conn),
 							  "secret_access_key",
 							  NULL);
 	if (config_tmp->secret_access_key == NULL) {
 		goto out;
 	}
 
-	config_tmp->bkt_name = vfs_ceph_rgw_parm(handle, "bucket", NULL);
+	config_tmp->bkt_name = vfs_ceph_rgw_parm(SNUM(handle->conn),
+						 "bucket",
+						 NULL);
 	if (config_tmp->bkt_name == NULL) {
 		goto out;
 	}
 
-	config_tmp->debug = lp_parm_bool(SNUM(handle->conn),
-					 "ceph_rgw",
-					 "debug",
-					 false);
+	config_tmp->debug = lp_parm_bool(-1, "ceph_rgw", "debug", false);
+
 	SMB_VFS_HANDLE_SET_DATA(handle,
 				config_tmp,
 				NULL,


### PR DESCRIPTION
Since librgw can only be initialized once per process, the initialization parameters (id, config_file, keyring_file, debug) are now read from the [global] section instead of per-share config. Per-share parameters (user_id, access_key, secret_access_key, bucket) are unaffected.

Prevents creating redundant librgw instances on every connect for the same client. Because librgw lacks reference counting, destroying an instance on any disconnect would invalidate handles used by other instances. librgw is now initialized and shut down only once